### PR TITLE
Purchase regions instead of writing directly into storage

### DIFF
--- a/chopstick/package-lock.json
+++ b/chopstick/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@acala-network/chopsticks": "0.9.4",
         "@polkadot/api": "^10.11.1",
+        "@polkadot/keyring": "^12.6.2",
         "ts-node": "^10.9.2"
       }
     },
@@ -329,29 +330,157 @@
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.1.tgz",
-      "integrity": "sha512-cicTctZr5Jy5vgNT2FsNiKoTZnz6zQkgDoIYv79NI+p1Fhwc9C+DN/iMCnk3Cm9vR2gSAd2fSV+Y5iKVDhAmUw==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
+      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
       "dependencies": {
-        "@polkadot/util": "12.6.1",
-        "@polkadot/util-crypto": "12.6.1",
+        "@polkadot/util": "12.6.2",
+        "@polkadot/util-crypto": "12.6.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.1",
-        "@polkadot/util-crypto": "12.6.1"
+        "@polkadot/util": "12.6.2",
+        "@polkadot/util-crypto": "12.6.2"
+      }
+    },
+    "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
+      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-textdecoder": "12.6.2",
+        "@polkadot/x-textencoder": "12.6.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
+      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
+      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
+      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
+      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.1.tgz",
-      "integrity": "sha512-pzyirxTYAnsx+6kyLYcUk26e4TLz3cX6p2KhTgAVW77YnpGX5VTKTbYykyXC8fXFd/migeQsLaa2raFN47mwoA==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
+      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
       "dependencies": {
-        "@polkadot/util": "12.6.1",
+        "@polkadot/util": "12.6.2",
         "@substrate/ss58-registry": "^1.44.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/util": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
+      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-textdecoder": "12.6.2",
+        "@polkadot/x-textencoder": "12.6.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-bigint": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
+      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
+      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
+      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
+      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -518,26 +647,106 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.1.tgz",
-      "integrity": "sha512-2ezWFLmdgeDXqB9NAUdgpp3s2rQztNrZLY+y0SJYNOG4ch+PyodTW/qSksnOrVGVdRhZ5OESRE9xvo9LYV5UAw==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
+      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
       "dependencies": {
-        "@noble/curves": "^1.2.0",
-        "@noble/hashes": "^1.3.2",
-        "@polkadot/networks": "12.6.1",
-        "@polkadot/util": "12.6.1",
-        "@polkadot/wasm-crypto": "^7.3.1",
-        "@polkadot/wasm-util": "^7.3.1",
-        "@polkadot/x-bigint": "12.6.1",
-        "@polkadot/x-randomvalues": "12.6.1",
-        "@scure/base": "^1.1.3",
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "12.6.2",
+        "@polkadot/util": "12.6.2",
+        "@polkadot/wasm-crypto": "^7.3.2",
+        "@polkadot/wasm-util": "^7.3.2",
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-randomvalues": "12.6.2",
+        "@scure/base": "^1.1.5",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "12.6.1"
+        "@polkadot/util": "12.6.2"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
+      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-textdecoder": "12.6.2",
+        "@polkadot/x-textencoder": "12.6.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
+      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
+      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
+      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.6.2",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textdecoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
+      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textencoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
+      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -678,6 +887,7 @@
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.1.tgz",
       "integrity": "sha512-1uVKlfYYbgIgGV5v1Dgn960cGovenWm5pmg+aTMeUGXVYiJwRD2zOpLyC1i/tP454iA74j74pmWb8Nkn0tJZUQ==",
+      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "12.6.1",
         "tslib": "^2.6.2"

--- a/chopstick/package.json
+++ b/chopstick/package.json
@@ -10,8 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ts-node": "^10.9.2",
+    "@acala-network/chopsticks": "0.9.4",
     "@polkadot/api": "^10.11.1",
-    "@acala-network/chopsticks": "0.9.4"
+    "@polkadot/keyring": "^12.6.2",
+    "ts-node": "^10.9.2"
   }
 }

--- a/chopstick/src/consts.ts
+++ b/chopstick/src/consts.ts
@@ -1,4 +1,4 @@
-export const UNIT = 10**12; // ROC has 12 decimals
+export const UNIT = 10 ** 12; // ROC has 12 decimals
 
 export const INITIAL_PRICE = 50 * UNIT;
 export const CORE_COUNT = 10;
@@ -9,12 +9,12 @@ export const FULL_MASK = "0xFFFFFFFFFFFFFFFFFFFF"; // hex encoded 80 bit bitmap.
 export const HALF_FULL_MASK = "0xFFFFFFFFFF0000000000"; // hex encoded 80 bit bitmap.
 
 export const CONFIG = {
-    advance_notice: 20,
-    interlude_length: 10,
-    leadin_length: 10,
-    ideal_bulk_proportion: 0,
-    limit_cores_offered: 50,
-    region_length: 30,
-    renewal_bump: 10,
-    contribution_timeout: 5,
-}
+  advance_notice: 20,
+  interlude_length: 10,
+  leadin_length: 10,
+  ideal_bulk_proportion: 0,
+  limit_cores_offered: 50,
+  region_length: 30,
+  renewal_bump: 10,
+  contribution_timeout: 5,
+};

--- a/chopstick/src/consts.ts
+++ b/chopstick/src/consts.ts
@@ -2,8 +2,8 @@ export const UNIT = 10**12; // ROC has 12 decimals
 
 export const INITIAL_PRICE = 50 * UNIT;
 export const CORE_COUNT = 10;
-export const TIMESLICE = 80; // one TIMESLICE is 80 relay chain blocks.
-export const TIMESLICE_PERIOD = 2; // one para block has a duration of two relay chain blocks.
+export const TIMESLICE_PERIOD = 80; // one para block has a duration of two relay chain blocks.
+export const IDEAL_CORES_SOLD = 5;
 
 export const FULL_MASK = "0xFFFFFFFFFFFFFFFFFFFF"; // hex encoded 80 bit bitmap.
 export const HALF_FULL_MASK = "0xFFFFFFFFFF0000000000"; // hex encoded 80 bit bitmap.

--- a/chopstick/src/init.ts
+++ b/chopstick/src/init.ts
@@ -1,102 +1,113 @@
-import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
+import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
-import {Timeslice} from "./types";
+import { Timeslice } from "./types";
 import * as consts from "./consts";
 
 const keyring = new Keyring({ type: "sr25519" });
 
 async function init() {
-    const coretimeWsProvider = new WsProvider("ws://127.0.0.1:8000");
-    const rococoWsProvider = new WsProvider("wss://rococo-rpc.polkadot.io/");
+  const coretimeWsProvider = new WsProvider("ws://127.0.0.1:8000");
+  const rococoWsProvider = new WsProvider("wss://rococo-rpc.polkadot.io/");
 
-    const coretimeApi = await ApiPromise.create({provider: coretimeWsProvider});
-    const rococoApi = await ApiPromise.create({provider: rococoWsProvider});
+  const coretimeApi = await ApiPromise.create({ provider: coretimeWsProvider });
+  const rococoApi = await ApiPromise.create({ provider: rococoWsProvider });
 
-    await startBulkSale(rococoApi, coretimeApi);
+  await startBulkSale(rococoApi, coretimeApi);
 }
 
 init().then(() => process.exit(0));
 
 async function startBulkSale(rococoApi: ApiPromise, coretimeApi: ApiPromise) {
-    const latestRcBlock = (await rococoApi.rpc.chain.getHeader()).number.toNumber()
-    await setStatus(coretimeApi, latestRcBlock);
-    console.log("status set");
-    await initializeSale(coretimeApi, latestRcBlock);
-    console.log("sale initialized");
+  const latestRcBlock = (
+    await rococoApi.rpc.chain.getHeader()
+  ).number.toNumber();
+  await setStatus(coretimeApi, latestRcBlock);
+  console.log("status set");
+  await initializeSale(coretimeApi, latestRcBlock);
+  console.log("sale initialized");
 
-    const alice = keyring.addFromUri("//Alice");
-    await cryptoWaitReady();
+  const alice = keyring.addFromUri("//Alice");
+  await cryptoWaitReady();
 
-    console.log(alice.address);
-    // Alice buys a region.
-    await purchaseRegion(coretimeApi, alice);
-    console.log("Region purchased")
+  console.log(alice.address);
+  // Alice buys a region.
+  await purchaseRegion(coretimeApi, alice);
+  console.log("Region purchased");
 }
 
-async function purchaseRegion(coretimeApi: ApiPromise, buyer: KeyringPair): Promise<void> {
-    const callTx = async (resolve: () => void) => {
-      const purchase = coretimeApi.tx.broker.purchase(consts.INITIAL_PRICE * 2);
-      console.log(purchase.data);
-      const unsub = await purchase.signAndSend(buyer, (result: any) => {
-        if (result.status.isInBlock) {
-          unsub();
-          resolve();
-        }
-      });
-    };
-
-    return new Promise(callTx);
-}
-
-async function setStatus(coretimeApi: ApiPromise, latestRcBlock: number): Promise<any> {
-    const commitTimeslice = getLatestTimesliceReadyToCommit(latestRcBlock);
-
-    const status = {
-        core_count: consts.CORE_COUNT,
-        private_pool_size: 0,
-        system_pool_size: 0,
-        last_committed_timeslice: currentTimeslice(commitTimeslice) - 1,
-        last_timeslice: currentTimeslice(latestRcBlock)
-    };
-
-    await coretimeApi.rpc('dev_setStorage', {
-    broker: {
-        status
-    }
-    })
-    return await coretimeApi.rpc('dev_newBlock');
-} 
-
-async function initializeSale(coretimeApi: ApiPromise, latestRcBlock: number): Promise<any> {
-    const now = (await coretimeApi.rpc.chain.getHeader()).number.toNumber()
-    const commitTimeslice = getLatestTimesliceReadyToCommit(latestRcBlock);
-
-    const saleInfo = {
-        sale_start: now,
-        leadin_length: consts.CONFIG.leadin_length,
-        price: consts.INITIAL_PRICE,
-        sellout_price: null,
-        region_begin: commitTimeslice,
-        region_end: commitTimeslice + consts.CONFIG.region_length,
-        first_core: 0,
-        ideal_cores_sold: consts.IDEAL_CORES_SOLD,
-        cores_offered: consts.CORE_COUNT,
-        cores_sold: 0,
-    }
-
-    return await coretimeApi.rpc('dev_setStorage', {
-    broker: {
-        saleInfo
-    }
+async function purchaseRegion(
+  coretimeApi: ApiPromise,
+  buyer: KeyringPair,
+): Promise<void> {
+  const callTx = async (resolve: () => void) => {
+    const purchase = coretimeApi.tx.broker.purchase(consts.INITIAL_PRICE * 2);
+    console.log(purchase.data);
+    const unsub = await purchase.signAndSend(buyer, (result: any) => {
+      if (result.status.isInBlock) {
+        unsub();
+        resolve();
+      }
     });
+  };
+
+  return new Promise(callTx);
+}
+
+async function setStatus(
+  coretimeApi: ApiPromise,
+  latestRcBlock: number,
+): Promise<any> {
+  const commitTimeslice = getLatestTimesliceReadyToCommit(latestRcBlock);
+
+  const status = {
+    core_count: consts.CORE_COUNT,
+    private_pool_size: 0,
+    system_pool_size: 0,
+    last_committed_timeslice: currentTimeslice(commitTimeslice) - 1,
+    last_timeslice: currentTimeslice(latestRcBlock),
+  };
+
+  await coretimeApi.rpc("dev_setStorage", {
+    broker: {
+      status,
+    },
+  });
+  return await coretimeApi.rpc("dev_newBlock");
+}
+
+async function initializeSale(
+  coretimeApi: ApiPromise,
+  latestRcBlock: number,
+): Promise<any> {
+  const now = (await coretimeApi.rpc.chain.getHeader()).number.toNumber();
+  const commitTimeslice = getLatestTimesliceReadyToCommit(latestRcBlock);
+
+  const saleInfo = {
+    sale_start: now,
+    leadin_length: consts.CONFIG.leadin_length,
+    price: consts.INITIAL_PRICE,
+    sellout_price: null,
+    region_begin: commitTimeslice,
+    region_end: commitTimeslice + consts.CONFIG.region_length,
+    first_core: 0,
+    ideal_cores_sold: consts.IDEAL_CORES_SOLD,
+    cores_offered: consts.CORE_COUNT,
+    cores_sold: 0,
+  };
+
+  return await coretimeApi.rpc("dev_setStorage", {
+    broker: {
+      saleInfo,
+    },
+  });
 }
 
 function currentTimeslice(latestRcBlock: number) {
-    return Math.floor(latestRcBlock / consts.TIMESLICE_PERIOD);
+  return Math.floor(latestRcBlock / consts.TIMESLICE_PERIOD);
 }
 
 function getLatestTimesliceReadyToCommit(latestRcBlock: number): Timeslice {
-    let advanced = latestRcBlock + consts.CONFIG.advance_notice;
-    return Math.floor(advanced / consts.TIMESLICE_PERIOD);
+  let advanced = latestRcBlock + consts.CONFIG.advance_notice;
+  return Math.floor(advanced / consts.TIMESLICE_PERIOD);
 }

--- a/chopstick/src/types.ts
+++ b/chopstick/src/types.ts
@@ -5,18 +5,18 @@ export type CoreMask = string;
 export type Balance = number;
 
 export type RegionId = {
-    begin: Timeslice,
-    core: CoreIndex,
-    mask: CoreMask,
+  begin: Timeslice;
+  core: CoreIndex;
+  mask: CoreMask;
 };
 
 export type RegionRecord = {
-    end: Timeslice,
-    owner: string,
-    paid: null | Balance,
+  end: Timeslice;
+  owner: string;
+  paid: null | Balance;
 };
 
 export type Region = {
-    regionId: RegionId,
-    regionRecord: RegionRecord,
+  regionId: RegionId;
+  regionRecord: RegionRecord;
 };


### PR DESCRIPTION
Now that the call filtered is removed from the Coretime chain we can purchase the regions using the extrinsic instead of writing directly into state.