### PR TITLE
Transfer region during initialization

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -4,12 +4,34 @@ import BN from "bn.js";
 import * as consts from "./consts";
 import { RegionId } from "./types";
 
-export async function purchaseRegion(coretimeApi: ApiPromise, buyer: KeyringPair): Promise<void> {
+export async function purchaseRegion(coretimeApi: ApiPromise, buyer: KeyringPair): Promise<RegionId> {
   log(`Purchasing a reigon.`);
 
-  const callTx = async (resolve: () => void) => {
+  const callTx = async (resolve: (regionId: RegionId) => void) => {
     const purchase = coretimeApi.tx.broker.purchase(consts.INITIAL_PRICE * 2);
-    const unsub = await purchase.signAndSend(buyer, (result: any) => {
+    const unsub = await purchase.signAndSend(buyer, async (result: any) => {
+      if (result.status.isInBlock) {
+        const regionId = await getRegionId(coretimeApi);
+        unsub();
+        resolve(regionId);
+      }
+    });
+  };
+
+  return new Promise(callTx);
+}
+
+export async function transferRegion(
+  coretimeApi: ApiPromise,
+  sender: KeyringPair,
+  receiver: string,
+  regionId: RegionId
+): Promise<void> {
+  log(`Transferring a reigon to ${receiver}`);
+
+  const callTx = async (resolve: () => void) => {
+    const transfer = coretimeApi.tx.broker.transfer(regionId, receiver);
+    const unsub = await transfer.signAndSend(sender, (result: any) => {
       if (result.status.isInBlock) {
         unsub();
         resolve();
@@ -18,6 +40,21 @@ export async function purchaseRegion(coretimeApi: ApiPromise, buyer: KeyringPair
   };
 
   return new Promise(callTx);
+}
+
+async function getRegionId(coretimeApi: ApiPromise): Promise<RegionId> {
+  log("Getting contract address");
+  const events: any = await coretimeApi.query.system.events();
+
+  for (const record of events) {
+    const { event } = record;
+    if (event.section === "broker" && event.method === "Purchased") {
+      log("Found RegionId: " + event.data[1].toString());
+      return event.data[1];
+    }
+  }
+
+  return { begin: 0, core: 0, mask: "" };
 }
 
 export function log(message: string) {

--- a/src/zombienet.init.ts
+++ b/src/zombienet.init.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { u8aToHex } from "@polkadot/util";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
-import { purchaseRegion, log, normalizePath, encodeRegionId } from "./common";
+import { purchaseRegion, log, normalizePath, encodeRegionId, transferRegion } from "./common";
 import { Abi, ContractPromise } from "@polkadot/api-contract";
 import { program } from "commander";
 import fs from "fs";
@@ -11,7 +11,11 @@ import process from "process";
 import type { WeightV2 } from "@polkadot/types/interfaces";
 import { BN, bnToBn } from "@polkadot/util";
 
-program.option("--fullNetwork").option("--contracts <string>").option("--account <string>");
+program
+  .option("--fullNetwork")
+  .option("--contracts <string>")
+  .option("--contractsAccount <string>")
+  .option("--coretimeAccount <string>");
 
 program.parse(process.argv);
 
@@ -43,10 +47,15 @@ async function init() {
 
   // Takes some time to get everything ready before being able to perform a purchase.
   await sleep(60000);
-  await purchaseRegion(coretimeApi, alice);
+  const regionId = await purchaseRegion(coretimeApi, alice);
+
+  const coretimeAccount = program.opts().coretimeAccount;
+  if (coretimeAccount) {
+    await transferRegion(coretimeApi, alice, coretimeAccount, regionId);
+  }
 
   if (program.opts().fullNetwork) {
-    const account = program.opts().account;
+    const account = program.opts().contractsAccount;
 
     await openHrmpChannel(rococoApi, CORETIME_CHAIN_PARA_ID, CONTRACTS_CHAIN_PARA_ID);
 


### PR DESCRIPTION
This PR enables the specification of a receiver account for a newly minted region, removing the need for manual configuration during frontend testing.